### PR TITLE
Add sub statistics for database queries

### DIFF
--- a/src/Debug/Entries/Query.php
+++ b/src/Debug/Entries/Query.php
@@ -7,8 +7,15 @@ use Soyhuce\DevTools\Tools\Time;
 
 class Query extends Entry
 {
+    public readonly string $sql;
+
+    public readonly float $duration;
+
     public function __construct(string $source, QueryExecuted $queryExecuted)
     {
+        $this->sql = $this->toReadableSql($queryExecuted);
+        $this->duration = $queryExecuted->time;
+
         parent::__construct(
             $source,
             $this->format($queryExecuted)
@@ -20,8 +27,8 @@ class Query extends Entry
     {
         return sprintf(
             '%s -> %s',
-            $this->toReadableSql($queryExecuted),
-            Time::humanizeMilliseconds($queryExecuted->time)
+            $this->sql,
+            Time::humanizeMilliseconds($this->duration)
         );
     }
 

--- a/tests/Feature/Debug/QueryCollectorTest.php
+++ b/tests/Feature/Debug/QueryCollectorTest.php
@@ -35,6 +35,7 @@ class QueryCollectorTest extends TestCase
                 return Str::containsAll($message, [
                     'database : select * from "users" where "email" = \'taylor@laravel.com\' limit 1 -> ',
                     'database : query executed :',
+                    'select :',
                 ]);
             });
 

--- a/tests/Feature/Debug/TimeCollectorTest.php
+++ b/tests/Feature/Debug/TimeCollectorTest.php
@@ -80,7 +80,7 @@ class TimeCollectorTest extends TestCase
     public function timerCannotBeStartedTwice(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectErrorMessage('A measure foo is already started');
+        $this->expectExceptionMessage('A measure foo is already started');
 
         Debug::startMeasure('foo');
         Debug::startMeasure('foo');
@@ -92,7 +92,7 @@ class TimeCollectorTest extends TestCase
     public function timerMustBeStartedBeforeStopped(): void
     {
         $this->expectException(LogicException::class);
-        $this->expectErrorMessage('A measure foo is not started');
+        $this->expectExceptionMessage('A measure foo is not started');
 
         Debug::stopMeasure('foo');
     }


### PR DESCRIPTION
This generates statistics for database queries, globally and per query type : 

```
=> [2023-08-23 07:31:04.737412] database : query executed : 15 / total duration 720μs (avg : 48μs - min : 20μs - max : 160μs - std : 37.98μs)
                                           select : 6 / total duration 300μs (avg : 50μs - min : 20μs - max : 160μs - std : 50μs)
                                           create : 6 / total duration 360μs (avg : 60μs - min : 30μs - max : 100μs - std : 23.8μs)
                                           insert : 3 / total duration 60μs (avg : 20μs - min : 20μs - max : 20μs - std : 0μs)
```
                                      